### PR TITLE
prepare for compiler bug fix

### DIFF
--- a/variant.nim
+++ b/variant.nim
@@ -118,7 +118,8 @@ proc mangledNameAux(t: NimNode): string =
 proc mangledName(t: NimNode): string =
     mangledNameAux(getTypeImpl(t)[1])
 
-macro getMangledName(t: typed): string = mangledName(t)
+macro getMangledName(t: typed): string =
+  result = newLit(mangledName(t))
 
 type TypeId* = Hash
 
@@ -132,7 +133,7 @@ macro getTypeId*(t: typed): TypeId =
         else:
             typeIds[h] = name
             break
-    return h
+    result = newLit(h)
 
 const debugVariantTypes = defined(variantDebugTypes)
 


### PR DESCRIPTION
There is a bug in the compiler where ``result = something`` and ``return something`` has different type errors. You currently rely on this bug and therefore the CI to fix this bug fails.

https://github.com/nim-lang/Nim/pull/9666

In the patched version of Nim you can then write the following, but this fails to compile on older version of Nim, so the assignment to result is used:

```nim
macro getMangledName(t: typed): string = newLit(mangledName(t))
```