### PR TITLE
change deprecated type pragma position

### DIFF
--- a/variant.nim
+++ b/variant.nim
@@ -147,7 +147,7 @@ proc canCastToPointer[T](): bool {.compileTime.} =
 
 when defined(gcDestructors):
     type
-        Variant* = ref object {.inheritable.}
+        Variant* {.inheritable.} = ref object
             typeId*: TypeId
             when debugVariantTypes:
                 mangledName*: string


### PR DESCRIPTION
This is not affected by https://github.com/nim-lang/Nim/issues/16653 since Variant is not generic.

Just for linking sake, this is because of https://github.com/nim-lang/Nim/pull/20199